### PR TITLE
FF-C54 [BE] - Push Notification when suggesting crops to user farmers…

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,34 @@ socket.on('connect', () => {
   console.log('Connected to socket.io server')
 })
 
+socket.on('automated_notification', async (data) => {
+  console.log('Received automated notification:', data)
+
+  // Request permissions (required for iOS)
+  await notifee.requestPermission()
+
+  // Create a channel (required for Android)
+  const channelId = await notifee.createChannel({
+    id: data.id,
+    name: 'FarmFriend Push Notification',
+    importance: AndroidImportance.HIGH,
+  })
+
+   // Display a notification
+   await notifee.displayNotification({
+    title: data.title,
+    body: data.message,
+    android: {
+      smallIcon: 'ic_launcher', 
+      channelId,
+      // pressAction is needed if you want the notification to open the app when pressed
+      pressAction: {
+        id: 'default',
+      }
+    },
+  })
+})
+
 socket.on('new_notification', async (data) => {
   console.log('Received new notification:', data)
 


### PR DESCRIPTION
[https://www.notion.so/Push-Notification-to-Users-d8973c8444aa47a8b4c94d2946426c54?pvs=4](https://www.notion.so/FF-C54-BE-Push-Notification-when-suggesting-crops-to-user-farmers-and-LGU-during-10-00-AM-and-4p-d8973c8444aa47a8b4c94d2946426c54?pvs=21)

Definition of Done:

- Suggest crops to user farmers and LGUs/NGOs (also admin) via push notification, suggested crops will be based on the Weather API and shows only during 10:00 AM and 4pm peak time
- Implement Notification to Suggest Crops (first 3) to Farmers and LGU based on the Weather API

DEVELOPERS DIFFICULTIES

- BOTH BACKEND AND FRONTEND NO TRIGGERING FOR AN EVENT
- Experiment on the package called https://novu.co/
- Probability Implementation 30%
- Also no time to implement or to learn this functionality

INITIAL SOLUTION

- Behind the scene Villaruel will manually trigger and event for push notification in the crops
- To run in administration authorization role
    - 50% probability to work this functionality

FINAL SOLUTION

- To manually trigger event in the admin website
- Further plan during presentation